### PR TITLE
Fix typo in library.properties category value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Patrick Fenner <contact@defproc.co.uk>
 maintainer=Patrick Fenner <contact@defproc.co.uk>
 sentence=A morse code stream/print interpreter
 paragraph=Lewis helps with receiving and sending morse code from a microcontroller
-category=Communiction
+category=Communication
 url=https://git.defproc.co.uk/DefProc/Lewis/
 architectures=*


### PR DESCRIPTION
This fixes the `WARNING: Category 'Communiction' in library Lewis is not valid. Setting to 'Uncategorized'` warning on every compile.
