### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,20 +2,20 @@
 # Datatypes (KEYWORD1)
 ######################
 
-Lewis KEYWORD1
+Lewis	KEYWORD1
 
 ######################
 # Funtions (KEYWORD2)
 ######################
 
-begin KEYWORD2
-available KEYWORD2
-read KEYWORD2
-peak KEYWORD2
-flush KEYWORD2
-flushRX KEYWORD2
-flushTX KEYWORD2
-write KEYWORD2
+begin	KEYWORD2
+available	KEYWORD2
+read	KEYWORD2
+peak	KEYWORD2
+flush	KEYWORD2
+flushRX	KEYWORD2
+flushTX	KEYWORD2
+write	KEYWORD2
 
 #######################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords